### PR TITLE
Remove unnecessary test nop commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,16 +45,7 @@
     "make:live": "bun run core/cli/index.ts make:component",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:watch": "vitest --watch",
-    "test:live": "tsx scripts/test-live-components.ts",
-    "test:live:coverage": "tsx scripts/test-live-components.ts --coverage",
-    "test:live:watch": "tsx scripts/test-live-components.ts --watch",
-    "test:live:verbose": "tsx scripts/test-live-components.ts --verbose",
-    "test:config": "bun run core/config/__tests__/run-tests.ts",
-    "test:config:coverage": "bun run core/config/__tests__/run-tests.ts coverage",
-    "test:config:manual": "bun run core/config/__tests__/manual-test.ts",
     "legacy:dev": "bun --watch app/server/index.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
Cleaned up package.json by removing 9 redundant test commands:
- test:run (redundant with 'test')
- test:watch (vitest has watch by default)
- test:live* (4 specific commands not in use)
- test:config* (3 specific commands not in use)

Kept only essential test commands:
- test: basic vitest command
- test:ui: visual debugging interface
- test:coverage: code coverage analysis