### PR TITLE
Remove Docker commands from package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "dev": "bun run core/cli/index.ts dev",
     "dev:frontend": "bun run core/cli/index.ts frontend",
     "dev:backend": "bun run core/cli/index.ts backend",
-    "dev:coordinated": "concurrently --prefix {name} --names BACKEND,VITE --prefix-colors blue,green --kill-others-on-fail \"bun --watch app/server/index.ts\" \"vite --config vite.config.ts\"",
     "sync-version": "bun run core/utils/sync-version.ts",
     "build": "cross-env NODE_ENV=production bun run core/cli/index.ts build",
     "build:frontend": "vite build --config vite.config.ts --emptyOutDir",
@@ -35,18 +34,13 @@
     "start": "bun run core/cli/index.ts start",
     "start:frontend": "bun run app/client/frontend-only.ts",
     "start:backend": "bun run app/server/backend-only.ts",
-    "docker:build": "cd dist && docker build -t fluxstack-app .",
-    "docker:run": "cd dist && docker run -p 3000:3000 fluxstack-app",
-    "docker:compose": "cd dist && docker-compose up -d",
-    "docker:stop": "cd dist && docker-compose down",
     "create": "bun run core/cli/index.ts create",
     "cli": "bun run core/cli/index.ts",
     "make:component": "bun run core/cli/index.ts make:component",
     "make:live": "bun run core/cli/index.ts make:component",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:coverage": "vitest run --coverage",
-    "legacy:dev": "bun --watch app/server/index.ts"
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",


### PR DESCRIPTION
Remove obsolete scripts that are no longer needed:
- Remove 4 Docker commands (docker:build, docker:run, docker:compose, docker:stop)
- Remove dev:coordinated (replaced by modern CLI system)
- Remove legacy:dev (marked as legacy)

These commands are superseded by the core/cli/index.ts system which provides a more robust and integrated development experience.