### PR TITLE
refactor: protect backend-only.ts logic in core framework

### DIFF
--- a/app/server/backend-only.ts
+++ b/app/server/backend-only.ts
@@ -1,15 +1,18 @@
-// Backend standalone entry point
-import { startBackendOnly } from "@/core/server/standalone"
+/**
+ * Backend Standalone Entry Point
+ *
+ * This is a minimal wrapper for starting the backend in standalone mode.
+ * The core logic is protected in @/core/server/backend-entry.ts
+ *
+ * You can customize the configuration here if needed.
+ */
+
+import { startBackend, createBackendConfig } from "@/core/server/backend-entry"
 import { apiRoutes } from "./routes"
 import { serverConfig } from "@/config/server.config"
 
-// Configuração para backend standalone usando config declarativo
-const backendConfig = {
-  port: serverConfig.backendPort,
-  apiPrefix: serverConfig.apiPrefix
-}
+// Create backend configuration from declarative config
+const backendConfig = createBackendConfig(serverConfig)
 
-console.log(`🚀 Backend standalone: ${serverConfig.host}:${backendConfig.port}`)
-
-// Iniciar apenas o backend
-startBackendOnly(apiRoutes, backendConfig)
+// Start backend in standalone mode
+startBackend(apiRoutes, backendConfig)

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "create-fluxstack",

--- a/core/cli/index.ts
+++ b/core/cli/index.ts
@@ -452,14 +452,18 @@ async function handleLegacyCommands() {
     console.log("🚀 API Server: http://localhost:3001")
     console.log("📦 Starting backend with hot reload...")
     console.log()
-    
+
+    // Ensure backend-only.ts exists
+    const { ensureBackendEntry } = await import("../utils/regenerate-files")
+    await ensureBackendEntry()
+
     // Start backend with Bun watch for hot reload
     const { spawn: spawnBackend } = await import("child_process")
     const backendProcess = spawnBackend("bun", ["--watch", "app/server/backend-only.ts"], {
       stdio: "inherit",
       cwd: process.cwd()
     })
-    
+
     // Handle process cleanup
     process.on('SIGINT', () => {
       backendProcess.kill('SIGINT')

--- a/core/server/backend-entry.ts
+++ b/core/server/backend-entry.ts
@@ -1,0 +1,51 @@
+/**
+ * Backend Entry Point - Core Framework
+ *
+ * This file contains the protected logic for running backend standalone mode.
+ * DO NOT modify this file directly - it's part of the FluxStack framework core.
+ *
+ * For customization, use app/server/backend-only.ts
+ */
+
+import type { Elysia } from "elysia"
+import { startBackendOnly } from "./standalone"
+
+export interface BackendEntryConfig {
+  port: number
+  apiPrefix?: string
+  host?: string
+}
+
+/**
+ * Start backend in standalone mode
+ *
+ * @param apiRoutes - Elysia routes from app/server/routes
+ * @param config - Backend configuration
+ */
+export function startBackend(
+  apiRoutes: Elysia,
+  config: BackendEntryConfig
+) {
+  const { port, apiPrefix = '/api', host = 'localhost' } = config
+
+  console.log(`🚀 Backend standalone: ${host}:${port}`)
+  console.log(`📡 API Prefix: ${apiPrefix}`)
+  console.log()
+
+  // Start backend using the standalone utility
+  startBackendOnly(apiRoutes, { port, apiPrefix })
+}
+
+/**
+ * Create backend entry config from declarative config
+ * Helper to make it easy to use with the config system
+ */
+export function createBackendConfig(
+  serverConfig: { server: { backendPort: number; apiPrefix: string; host: string } }
+): BackendEntryConfig {
+  return {
+    port: serverConfig.server.backendPort,
+    apiPrefix: serverConfig.server.apiPrefix,
+    host: serverConfig.server.host
+  }
+}

--- a/core/utils/regenerate-files.ts
+++ b/core/utils/regenerate-files.ts
@@ -1,0 +1,69 @@
+/**
+ * File Regeneration Utilities
+ *
+ * Provides functions to regenerate critical application files that might be
+ * accidentally deleted by developers.
+ */
+
+import { join } from "path"
+import { existsSync } from "fs"
+
+const BACKEND_ONLY_TEMPLATE = `/**
+ * Backend Standalone Entry Point
+ *
+ * This is a minimal wrapper for starting the backend in standalone mode.
+ * The core logic is protected in @/core/server/backend-entry.ts
+ *
+ * You can customize the configuration here if needed.
+ */
+
+import { startBackend, createBackendConfig } from "@/core/server/backend-entry"
+import { apiRoutes } from "./routes"
+import { serverConfig } from "@/config/server.config"
+
+// Create backend configuration from declarative config
+const backendConfig = createBackendConfig(serverConfig)
+
+// Start backend in standalone mode
+startBackend(apiRoutes, backendConfig)
+`
+
+/**
+ * Check if backend-only.ts exists, regenerate if missing
+ */
+export async function ensureBackendEntry(projectRoot: string = process.cwd()): Promise<boolean> {
+  const backendOnlyPath = join(projectRoot, "app/server/backend-only.ts")
+
+  if (!existsSync(backendOnlyPath)) {
+    console.log("⚠️  backend-only.ts not found, regenerating...")
+
+    try {
+      await Bun.write(backendOnlyPath, BACKEND_ONLY_TEMPLATE)
+      console.log("✅ backend-only.ts regenerated successfully")
+      return true
+    } catch (error) {
+      console.error("❌ Failed to regenerate backend-only.ts:", error)
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Regenerate backend-only.ts file
+ */
+export async function regenerateBackendEntry(projectRoot: string = process.cwd()): Promise<boolean> {
+  const backendOnlyPath = join(projectRoot, "app/server/backend-only.ts")
+
+  console.log("🔄 Regenerating backend-only.ts...")
+
+  try {
+    await Bun.write(backendOnlyPath, BACKEND_ONLY_TEMPLATE)
+    console.log("✅ backend-only.ts regenerated successfully")
+    return true
+  } catch (error) {
+    console.error("❌ Failed to regenerate backend-only.ts:", error)
+    return false
+  }
+}

--- a/plugins/crypto-auth/bun.lock
+++ b/plugins/crypto-auth/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@fluxstack/crypto-auth-plugin",


### PR DESCRIPTION
## Changes
- Create `core/server/backend-entry.ts` with protected backend logic
- Simplify `app/server/backend-only.ts` to minimal wrapper
- Add `core/utils/regenerate-files.ts` for automatic file regeneration
- Update CLI to ensure backend-only.ts exists before starting
- Fix config access to handle nested server configuration

## Benefits
✅ Critical logic protected in core (read-only)
✅ Auto-regeneration if developer deletes the file
✅ Maintains flexibility for customization in app/
✅ Consistent pattern across framework

## Testing
✅ Backend standalone starts correctly on port 3001 ✅ Auto-regeneration works when file is deleted
✅ Config properly accesses nested server.backendPort