### PR TITLE
refactor: improve backend startup logs with clean table format

### DIFF
--- a/core/cli/index.ts
+++ b/core/cli/index.ts
@@ -448,11 +448,6 @@ async function handleLegacyCommands() {
     break
 
   case "backend":
-    console.log("⚡ FluxStack Backend Development")
-    console.log("🚀 API Server: http://localhost:3001")
-    console.log("📦 Starting backend with hot reload...")
-    console.log()
-
     // Ensure backend-only.ts exists
     const { ensureBackendEntry } = await import("../utils/regenerate-files")
     await ensureBackendEntry()

--- a/core/server/backend-entry.ts
+++ b/core/server/backend-entry.ts
@@ -28,12 +28,8 @@ export function startBackend(
 ) {
   const { port, apiPrefix = '/api', host = 'localhost' } = config
 
-  console.log(`🚀 Backend standalone: ${host}:${port}`)
-  console.log(`📡 API Prefix: ${apiPrefix}`)
-  console.log()
-
   // Start backend using the standalone utility
-  startBackendOnly(apiRoutes, { port, apiPrefix })
+  startBackendOnly(apiRoutes, { port, apiPrefix, host })
 }
 
 /**

--- a/core/server/standalone.ts
+++ b/core/server/standalone.ts
@@ -39,13 +39,48 @@ export const createStandaloneServer = (userConfig: any = {}) => {
   return app
 }
 
+/**
+ * Create a simple table-like output
+ */
+function printTable(data: Record<string, string>, title?: string) {
+  const maxKeyLength = Math.max(...Object.keys(data).map(k => k.length))
+  const maxValueLength = Math.max(...Object.values(data).map(v => v.length))
+  const tableWidth = maxKeyLength + maxValueLength + 7
+
+  const border = '─'.repeat(tableWidth)
+
+  if (title) {
+    console.log(`┌${border}┐`)
+    const padding = Math.floor((tableWidth - title.length) / 2)
+    console.log(`│${' '.repeat(padding)}${title}${' '.repeat(tableWidth - padding - title.length)}│`)
+    console.log(`├${border}┤`)
+  } else {
+    console.log(`┌${border}┐`)
+  }
+
+  Object.entries(data).forEach(([key, value]) => {
+    const keyPadded = key.padEnd(maxKeyLength)
+    const valuePadded = value.padEnd(maxValueLength)
+    console.log(`│ ${keyPadded} │ ${valuePadded} │`)
+  })
+
+  console.log(`└${border}┘`)
+}
+
 export const startBackendOnly = async (userRoutes?: any, config: any = {}) => {
   const port = config.port || process.env.BACKEND_PORT || 3000
-  const host = process.env.HOST || 'localhost'
-  
-  console.log(`🦊 FluxStack Backend`)
-  console.log(`🚀 http://${host}:${port}`)
-  console.log(`📋 Health: http://${host}:${port}/health`)
+  const host = config.host || process.env.HOST || 'localhost'
+  const apiPrefix = config.apiPrefix || '/api'
+
+  // Display server information in a clean table
+  printTable({
+    'Mode': 'Backend Standalone',
+    'Server': `http://${host}:${port}`,
+    'API Prefix': apiPrefix,
+    'Health Check': `http://${host}:${port}/health`,
+    'Hot Reload': 'Enabled'
+  }, 'FluxStack Backend Server')
+
   console.log()
 
   const app = createStandaloneServer(config)


### PR DESCRIPTION
## Changes
- Remove duplicate logs from CLI (core/cli/index.ts)
- Remove duplicate logs from backend-entry.ts
- Add printTable() function to standalone.ts for clean formatting
- Display server info in professional table format

## Output Example
┌───────────────────────────────────────────────┐
│           FluxStack Backend Server            │
├───────────────────────────────────────────────┤
│ Mode         │ Backend Standalone           │
│ Server       │ http://localhost:3001        │
│ API Prefix   │ /api                         │
│ Health Check │ http://localhost:3001/health │
│ Hot Reload   │ Enabled                      │
└───────────────────────────────────────────────┘

## Benefits
- No more duplicate startup messages
- Professional table-based presentation
- Clear and organized server information
- Removed unnecessary emoji clutter
- Single source of truth for startup logs