### PR TITLE
fix: correct lock file name in Dockerfile (bun.lockb → bun.lock)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -64,7 +64,7 @@ temp/
 *.swo
 *~
 
-# Lock files (using bun.lockb only)
+# Lock files (exclude other package managers, keep bun.lock)
 package-lock.json
 yarn.lock
 pnpm-lock.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM oven/bun:1.1.34-alpine AS deps
 WORKDIR /app
 
 # Copy package files
-COPY package.json bun.lockb ./
+COPY package.json bun.lock ./
 
 # Install production dependencies only
 RUN bun install --production --frozen-lockfile
@@ -22,7 +22,7 @@ FROM oven/bun:1.1.34-alpine AS builder
 WORKDIR /app
 
 # Copy package files and install all dependencies (including dev)
-COPY package.json bun.lockb ./
+COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 
 # Copy source code


### PR DESCRIPTION
## Problem:
Docker build was failing with error:
`"/bun.lockb": not found`

## Root Cause:
- Dockerfile referenced `bun.lockb` (standard Bun lockfile name)
- Project actually uses `bun.lock` (alternate naming)

## Solution:
- Updated Dockerfile to use `bun.lock` in both stages:
  - Stage 1 (deps): COPY package.json bun.lock ./
  - Stage 2 (builder): COPY package.json bun.lock ./
- Updated .dockerignore comment for clarity

## Testing:
Docker build will now find the correct lockfile and proceed with installation.

## Files Changed:
- Dockerfile: bun.lockb → bun.lock (2 occurrences)
- .dockerignore: Updated comment to reflect bun.lock usage