### PR TITLE
Fix the email functionality

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -7,7 +7,19 @@ target = "bun"
 cache = true
 lockfile = true
 
-# Path mapping (alias support)
+# Path mapping for runtime execution
+[run]
+preload = []
+
+# Path mapping (alias support) for runtime
+[run.alias]
+"@" = "."
+"@/core" = "./core"
+"@/app" = "./app"
+"@/config" = "./config"
+"@/shared" = "./app/shared"
+
+# Path mapping (alias support) for build
 [build.alias]
 "@" = "."
 "@/core" = "./core"


### PR DESCRIPTION
- Added [run.alias] section to bunfig.toml
- Duplicated path aliases for both runtime and build phases
- Resolves module resolution errors during Docker build
- Fixes "Cannot find module '@/config/logger.config'" error

The Bun runtime needs path aliases configured in both [run.alias] and [build.alias] sections to properly resolve TypeScript path mappings during execution and build phases.