### PR TITLE
Find where file is being used

### DIFF
--- a/app/server/app.ts
+++ b/app/server/app.ts
@@ -1,9 +1,19 @@
-// Export the main app type for Eden Treaty
+// Export the main app instance and type for Eden Treaty
 import { apiRoutes } from "./routes"
 import { Elysia } from "elysia"
 
-// Create the full app structure that matches the server
-const appInstance = new Elysia()
+/**
+ * App Instance - Single Source of Truth
+ *
+ * This instance is used by:
+ * - index.ts (full-stack mode)
+ * - backend-only.ts (backend standalone mode)
+ * - Eden Treaty client (type inference)
+ *
+ * This ensures that the type exported for Eden Treaty is exactly
+ * the same as what the server uses.
+ */
+export const appInstance = new Elysia()
   .use(apiRoutes)
 
 // Export the type correctly for Eden Treaty

--- a/app/server/backend-only.ts
+++ b/app/server/backend-only.ts
@@ -8,11 +8,11 @@
  */
 
 import { startBackend, createBackendConfig } from "@/core/server/backend-entry"
-import { apiRoutes } from "./routes"
+import { appInstance } from "./app"
 import { serverConfig } from "@/config/server.config"
 
 // Create backend configuration from declarative config
 const backendConfig = createBackendConfig(serverConfig)
 
 // Start backend in standalone mode
-startBackend(apiRoutes, backendConfig)
+startBackend(appInstance, backendConfig)

--- a/app/server/index.ts
+++ b/app/server/index.ts
@@ -2,7 +2,7 @@
 import { FluxStackFramework, vitePlugin, swaggerPlugin, staticPlugin, liveComponentsPlugin, staticFilesPlugin } from "@/core/server"
 import { isDevelopment } from "@/core/utils/helpers"
 import { DEBUG } from "@/core/utils/logger"
-import { apiRoutes } from "./routes"
+import { appInstance } from "./app"
 import { helpers } from "@/core/utils/env"
 import { serverConfig } from "@/config/server.config"
 import { appConfig } from "@/config/app.config"
@@ -111,7 +111,7 @@ app.getApp().get('/api/env-test', () => {
 })
 
 // Registrar rotas da aplicação DEPOIS da rota de teste
-app.routes(apiRoutes)
+app.routes(appInstance)
 
 // Swagger por último para descobrir todas as rotas
 app.use(swaggerPlugin)


### PR DESCRIPTION
Changes:
- Export appInstance from app.ts for reuse
- Update index.ts to use appInstance instead of apiRoutes
- Update backend-only.ts to use appInstance
- Ensures Eden Treaty types match server implementation exactly

Benefits:
- Single source of truth for application routes
- Better type safety for Eden Treaty client
- Consistent behavior across full-stack and backend-only modes
- Improved maintainability