### PR TITLE
Register legacy CLI commands in new system

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev:backend": "bun run core/cli/index.ts backend",
     "sync-version": "bun run core/utils/sync-version.ts",
     "build": "cross-env NODE_ENV=production bun run core/cli/index.ts build",
-    "build:frontend": "vite build --config vite.config.ts --emptyOutDir",
+    "build:frontend": "bun run core/cli/index.ts build:frontend",
     "build:backend": "bun run core/cli/index.ts build:backend",
     "start": "bun run core/cli/index.ts start",
     "start:frontend": "bun run app/client/frontend-only.ts",


### PR DESCRIPTION
Adds missing CLI commands that existed in legacy system:
- `frontend` - start frontend dev server only (port 5173)
- `backend` - start backend dev server only (port 3001)
- `start` - start production server from dist/
- `build:frontend` - shortcut for `build --frontend-only`
- `build:backend` - shortcut for `build --backend-only`

All commands are now registered in the modern CLI registry with proper documentation, options, and examples.

Updated package.json to use CLI commands consistently.

Fixes: #CLI-COMMANDS-MISSING