### PR TITLE
Review plugin configuration schema design

### DIFF
--- a/core/plugins/types.ts
+++ b/core/plugins/types.ts
@@ -96,11 +96,31 @@ export namespace FluxStack {
   onError?: (context: ErrorContext) => void | Promise<void>
   onBuild?: (context: BuildContext) => void | Promise<void>
   onBuildComplete?: (context: BuildContext) => void | Promise<void>
-  
+
   // Configuration
+  /**
+   * @deprecated Use declarative config system instead (plugins/[name]/config/)
+   * Create a config/ folder with defineConfig() for type-safe configuration.
+   * This property is kept for backward compatibility with built-in plugins.
+   *
+   * @example
+   * // ✅ New way (recommended):
+   * // plugins/my-plugin/config/index.ts
+   * import { defineConfig, config } from '@/core/utils/config-schema'
+   * export const myConfig = defineConfig({ ... })
+   *
+   * // ❌ Old way (deprecated):
+   * configSchema: { type: 'object', properties: { ... } }
+   */
   configSchema?: PluginConfigSchema
+
+  /**
+   * @deprecated Use declarative config system with defineConfig()
+   * This property will be removed in a future major version.
+   * Use the config/ folder structure for automatic type inference.
+   */
   defaultConfig?: any
-  
+
   // CLI commands
   commands?: CliCommand[]
   }

--- a/plugins/crypto-auth/index.ts
+++ b/plugins/crypto-auth/index.ts
@@ -25,38 +25,10 @@ export const cryptoAuthPlugin: Plugin = {
   category: "auth",
   tags: ["authentication", "ed25519", "cryptography", "security"],
   dependencies: [],
-  
-  configSchema: {
-    type: "object",
-    properties: {
-      enabled: {
-        type: "boolean",
-        description: "Habilitar autenticação criptográfica"
-      },
-      maxTimeDrift: {
-        type: "number",
-        minimum: 30000,
-        description: "Máximo drift de tempo permitido em millisegundos (previne replay attacks)"
-      },
-      adminKeys: {
-        type: "array",
-        items: { type: "string" },
-        description: "Chaves públicas dos administradores (hex 64 caracteres)"
-      },
-      enableMetrics: {
-        type: "boolean",
-        description: "Habilitar métricas de autenticação"
-      }
-    },
-    additionalProperties: false
-  },
 
-  defaultConfig: {
-    enabled: true,
-    maxTimeDrift: 300000, // 5 minutos
-    adminKeys: [],
-    enableMetrics: true
-  },
+  // ✅ Plugin usa sistema declarativo de configuração (plugins/crypto-auth/config/)
+  // ❌ Removido: configSchema e defaultConfig (redundante com nova estrutura)
+  // 📖 Configuração gerenciada por defineConfig() com type inference automática
 
   // CLI Commands
   commands: [


### PR DESCRIPTION
**Problem:**
- crypto-auth had BOTH declarative config (config/) AND legacy configSchema/defaultConfig
- This created duplication and confusion about which system to use

**Changes:**
1. ✅ Removed configSchema and defaultConfig from crypto-auth plugin
2. ✅ Added deprecation warnings to Plugin interface
3. ✅ Documented migration path to declarative config system

**Benefits:**
- Eliminates config duplication
- Uses type-safe defineConfig() as single source of truth
- Provides clear migration path for other plugins
- Maintains backward compatibility for built-in plugins

**Config now managed by:**
`plugins/crypto-auth/config/index.ts` using FluxStack's declarative config system

Related issue: Plugin config system review