### PR TITLE
Fix failing user validation test status code

### DIFF
--- a/app/server/routes/users.routes.ts
+++ b/app/server/routes/users.routes.ts
@@ -74,8 +74,8 @@ export const usersRoutes = new Elysia({ prefix: '/users' })
     return result
   }, {
     body: t.Object({
-      name: t.String(),
-      email: t.String()
+      name: t.Optional(t.String()),
+      email: t.Optional(t.String())
     })
   })
 

--- a/tests/integration/api/users.routes.test.ts
+++ b/tests/integration/api/users.routes.test.ts
@@ -135,7 +135,7 @@ describe('Users API Routes', () => {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(incompleteData)
         }))
-        
+
       expect(response.status).toBe(400)
     })
 


### PR DESCRIPTION
… code

- Made TypeBox schema fields optional (t.Optional) to allow manual validation
- Ensures consistent 400 status code for validation errors across environments
- Fixes test expectation mismatch where TypeBox returned 422 in some environments
- Maintains custom error messages from manual validation
- Resolves inconsistency between Bun 1.1.34 (CI) and Bun 1.3.2 (local)

All tests now passing (11/11 in users.routes.test.ts)