### PR TITLE
Fix URL parsing error in error handler

### DIFF
--- a/core/cli/generators/route.ts
+++ b/core/cli/generators/route.ts
@@ -62,7 +62,15 @@ const controller = new {{pascalName}}Controller()
 export const {{camelName}}Routes = new Elysia({ prefix: '/api/{{kebabName}}s' })
   .use(errorHandler)
   .onBeforeHandle(({ request }) => {
-    logger.request(request.method, new URL(request.url).pathname)
+    const url = (() => {
+      try {
+        return new URL(request.url)
+      } catch {
+        const host = request.headers.get('host') || 'localhost'
+        return new URL(request.url, \`http://\${host}\`)
+      }
+    })()
+    logger.request(request.method, url.pathname)
   })
   .get('/', async () => {
     return await controller.getAll()
@@ -309,7 +317,15 @@ const controller = new AuthController()
 export const authRoutes = new Elysia({ prefix: '/api/auth' })
   .use(errorHandler)
   .onBeforeHandle(({ request }) => {
-    logger.request(request.method, new URL(request.url).pathname)
+    const url = (() => {
+      try {
+        return new URL(request.url)
+      } catch {
+        const host = request.headers.get('host') || 'localhost'
+        return new URL(request.url, \`http://\${host}\`)
+      }
+    })()
+    logger.request(request.method, url.pathname)
   })
   .post('/register', async ({ body }) => {
     return await controller.register({ body })

--- a/core/plugins/built-in/vite/index.ts
+++ b/core/plugins/built-in/vite/index.ts
@@ -6,6 +6,21 @@ type Plugin = FluxStack.Plugin
 
 let viteServer: ViteDevServer | null = null
 
+/**
+ * Helper to safely parse request.url which might be relative or absolute
+ */
+function parseRequestURL(request: Request): URL {
+  try {
+    // Try parsing as absolute URL first
+    return new URL(request.url)
+  } catch {
+    // If relative, use host from headers or default to localhost
+    const host = request.headers.get('host') || 'localhost'
+    const protocol = request.headers.get('x-forwarded-proto') || 'http'
+    return new URL(request.url, `${protocol}://${host}`)
+  }
+}
+
 export const vitePlugin: Plugin = {
   name: "vite",
   version: FLUXSTACK_VERSION,
@@ -186,7 +201,7 @@ export const vitePlugin: Plugin = {
       const vitePort = 5173
 
       try {
-        const url = new URL(requestContext.request.url)
+        const url = parseRequestURL(requestContext.request)
         const viteUrl = `http://${viteHost}:${vitePort}${requestContext.path}${url.search}`
 
         // Forward request to Vite
@@ -222,7 +237,7 @@ export const vitePlugin: Plugin = {
     const vitePort = 5173
 
     try {
-      const url = new URL(requestContext.request.url)
+      const url = parseRequestURL(requestContext.request)
       const viteUrl = `http://${viteHost}:${vitePort}${requestContext.path}${url.search}`
 
       // Forward request to Vite

--- a/core/plugins/manager.ts
+++ b/core/plugins/manager.ts
@@ -25,6 +25,21 @@ import { createPluginUtils } from "./config"
 import { FluxStackError } from "@/core/utils/errors"
 import { EventEmitter } from "events"
 
+/**
+ * Helper to safely parse request.url which might be relative or absolute
+ */
+function parseRequestURL(request: Request): URL {
+  try {
+    // Try parsing as absolute URL first
+    return new URL(request.url)
+  } catch {
+    // If relative, use host from headers or default to localhost
+    const host = request.headers.get('host') || 'localhost'
+    const protocol = request.headers.get('x-forwarded-proto') || 'http'
+    return new URL(request.url, `${protocol}://${host}`)
+  }
+}
+
 export interface PluginManagerConfig {
   config: FluxStackConfig
   logger: Logger
@@ -558,7 +573,7 @@ export class PluginManager extends EventEmitter {
  * Create request context from HTTP request
  */
 export function createRequestContext(request: Request, additionalData: any = {}): RequestContext {
-  const url = new URL(request.url)
+  const url = parseRequestURL(request)
   
   return {
     request,

--- a/create-fluxstack.ts
+++ b/create-fluxstack.ts
@@ -174,7 +174,14 @@ export class MyPlugin implements FluxStackPlugin {
   // Intercept every request
   async onRequest(context: PluginContext, request: Request): Promise<void> {
     // Example: Add custom headers
-    const url = new URL(request.url)
+    const url = (() => {
+      try {
+        return new URL(request.url)
+      } catch {
+        const host = request.headers.get('host') || 'localhost'
+        return new URL(request.url, \`http://\${host}\`)
+      }
+    })()
     console.log(\`[\${this.name}] Request to: \${url.pathname}\`)
 
     // Example: Validate authentication

--- a/plugins/crypto-auth/server/middlewares/helpers.ts
+++ b/plugins/crypto-auth/server/middlewares/helpers.ts
@@ -5,6 +5,21 @@
 
 import type { Logger } from '@/core/utils/logger'
 
+/**
+ * Helper to safely parse request.url which might be relative or absolute
+ */
+function parseRequestURL(request: Request): URL {
+  try {
+    // Try parsing as absolute URL first
+    return new URL(request.url)
+  } catch {
+    // If relative, use host from headers or default to localhost
+    const host = request.headers.get('host') || 'localhost'
+    const protocol = request.headers.get('x-forwarded-proto') || 'http'
+    return new URL(request.url, `${protocol}://${host}`)
+  }
+}
+
 export interface CryptoAuthUser {
   publicKey: string
   isAdmin: boolean
@@ -65,7 +80,7 @@ export function extractAuthHeaders(request: Request): {
  * Build message for signature verification
  */
 export function buildMessage(request: Request): string {
-  const url = new URL(request.url)
+  const url = parseRequestURL(request)
   return `${request.method}:${url.pathname}`
 }
 


### PR DESCRIPTION
Fixed TypeError: "/" cannot be parsed as a URL by adding parseRequestURL helper function that safely handles both absolute and relative URLs.

Changes:
- Added parseRequestURL helper in core/framework/server.ts
- Added parseRequestURL helper in core/plugins/built-in/vite/index.ts
- Added parseRequestURL helper in core/server/standalone.ts
- Added parseRequestURL helper in plugins/crypto-auth/server/middlewares/helpers.ts
- Added parseRequestURL helper in core/plugins/manager.ts
- Updated route generator templates in core/cli/generators/route.ts
- Updated plugin example in create-fluxstack.ts

The helper tries to parse as absolute URL first, then falls back to constructing URL using host header if relative path is provided.

Fixes parsing errors in production builds where request.url may contain only the path component (e.g., "/") instead of full URL.