### PR TITLE
docs: add comprehensive Swagger documentation for Users API routes

### DIFF
--- a/ai-context/reference/live-components-api.md
+++ b/ai-context/reference/live-components-api.md
@@ -1,0 +1,705 @@
+# Live Components API Reference
+
+## Visão Geral
+
+O **Live Components Plugin** é um sistema de componentes reativos em tempo real que utiliza WebSockets para comunicação bidirecional entre cliente e servidor. Inspirado no Laravel Livewire e Phoenix LiveView.
+
+### Características
+
+- ✅ **WebSocket Nativo**: Implementado com suporte nativo do Elysia
+- ✅ **Type Safety**: Inferência automática de tipos com Eden Treaty
+- ✅ **Performance Monitoring**: Monitoramento integrado de métricas
+- ✅ **Connection Management**: Gerenciamento robusto de conexões
+- ✅ **File Upload**: Suporte para upload de arquivos via WebSocket
+- ✅ **Connection Pooling**: Pools de conexões para escalabilidade
+
+---
+
+## Endpoints HTTP
+
+Todas as rotas Live Components estão sob o prefixo `/api/live` e agrupadas com a tag **"Live Components"** no Swagger.
+
+### 1. Informações e Estatísticas
+
+#### `GET /api/live/websocket-info`
+
+Retorna informações sobre o endpoint WebSocket e estatísticas do connection manager.
+
+**Tags**: `Live Components`, `WebSocket`
+
+**Response**:
+```typescript
+{
+  success: boolean
+  message: string
+  endpoint: string              // "ws://localhost:3000/api/live/ws"
+  status: string                // "running"
+  connectionManager: {
+    totalConnections: number
+    activeConnections: number
+    totalPools: number
+    totalQueuedMessages: number
+    maxConnections: number
+    connectionUtilization: number
+  }
+}
+```
+
+**Exemplo**:
+```bash
+curl http://localhost:3000/api/live/websocket-info
+```
+
+---
+
+#### `GET /api/live/stats`
+
+Retorna estatísticas sobre componentes registrados e instâncias ativas.
+
+**Tags**: `Live Components`, `Monitoring`
+
+**Response**:
+```typescript
+{
+  success: boolean
+  stats: {
+    components: number           // Total de componentes registrados
+    instances: number            // Total de instâncias ativas
+    connections: number          // Total de conexões WebSocket
+  }
+  timestamp: string              // ISO 8601
+}
+```
+
+---
+
+#### `GET /api/live/health`
+
+Verifica o status de saúde do serviço Live Components.
+
+**Tags**: `Live Components`, `Health`
+
+**Response**:
+```typescript
+{
+  success: boolean
+  service: string                // "FluxStack Live Components"
+  status: string                 // "operational"
+  components: number
+  connections: {
+    totalConnections: number
+    activeConnections: number
+    // ... outras métricas
+  }
+  uptime: number                 // Segundos desde o boot
+  timestamp: string
+}
+```
+
+---
+
+### 2. Gerenciamento de Conexões
+
+#### `GET /api/live/connections`
+
+Lista todas as conexões WebSocket ativas com suas métricas.
+
+**Tags**: `Live Components`, `Connections`
+
+**Response**:
+```typescript
+{
+  success: boolean
+  connections: Array<{
+    id: string
+    connectedAt: string
+    lastActivity: string
+    messagesSent: number
+    messagesReceived: number
+    // ... outras métricas
+  }>
+  systemStats: {
+    totalConnections: number
+    activeConnections: number
+    // ...
+  }
+  timestamp: string
+}
+```
+
+---
+
+#### `GET /api/live/connections/:connectionId`
+
+Retorna métricas detalhadas para uma conexão específica.
+
+**Tags**: `Live Components`, `Connections`
+
+**Parameters**:
+- `connectionId` (string) - O identificador único da conexão
+
+**Response (sucesso)**:
+```typescript
+{
+  success: true
+  connection: {
+    id: string
+    connectedAt: string
+    lastActivity: string
+    messagesSent: number
+    messagesReceived: number
+    components: number           // Componentes montados nesta conexão
+    // ... métricas detalhadas
+  }
+  timestamp: string
+}
+```
+
+**Response (erro)**:
+```typescript
+{
+  success: false
+  error: "Connection not found"
+}
+```
+
+---
+
+#### `GET /api/live/pools/:poolId/stats`
+
+Retorna estatísticas para um pool de conexões específico.
+
+**Tags**: `Live Components`, `Connections`, `Pools`
+
+**Parameters**:
+- `poolId` (string) - O identificador único do pool
+
+**Response (sucesso)**:
+```typescript
+{
+  success: true
+  pool: string
+  stats: {
+    size: number
+    active: number
+    idle: number
+    utilization: number
+    // ...
+  }
+  timestamp: string
+}
+```
+
+**Response (erro)**:
+```typescript
+{
+  success: false
+  error: "Pool not found"
+}
+```
+
+---
+
+### 3. Monitoramento de Performance
+
+#### `GET /api/live/performance/dashboard`
+
+Retorna dados completos do dashboard de monitoramento de performance.
+
+**Tags**: `Live Components`, `Performance`
+
+**Response**:
+```typescript
+{
+  success: boolean
+  dashboard: {
+    overview: {
+      totalComponents: number
+      totalInstances: number
+      avgResponseTime: number
+      // ...
+    }
+    metrics: Array<{
+      componentId: string
+      renderTime: number
+      updateTime: number
+      messageLatency: number
+      // ...
+    }>
+    alerts: Array<{
+      id: string
+      severity: "low" | "medium" | "high" | "critical"
+      message: string
+      timestamp: string
+    }>
+  }
+  timestamp: string
+}
+```
+
+---
+
+#### `GET /api/live/performance/components/:componentId`
+
+Retorna métricas de performance, alertas e sugestões para um componente específico.
+
+**Tags**: `Live Components`, `Performance`
+
+**Parameters**:
+- `componentId` (string) - O identificador único do componente
+
+**Response (sucesso)**:
+```typescript
+{
+  success: true
+  component: string
+  metrics: {
+    avgRenderTime: number
+    avgUpdateTime: number
+    avgMessageLatency: number
+    totalRenders: number
+    totalUpdates: number
+    errorRate: number
+    // ...
+  }
+  alerts: Array<{
+    id: string
+    type: string
+    severity: string
+    message: string
+    timestamp: string
+  }>
+  suggestions: Array<{
+    type: string
+    priority: string
+    description: string
+    estimatedImpact: string
+  }>
+  timestamp: string
+}
+```
+
+**Response (erro)**:
+```typescript
+{
+  success: false
+  error: "Component metrics not found"
+}
+```
+
+---
+
+#### `POST /api/live/performance/alerts/:alertId/resolve`
+
+Marca um alerta de performance como resolvido.
+
+**Tags**: `Live Components`, `Performance`, `Alerts`
+
+**Parameters**:
+- `alertId` (string) - O identificador único do alerta
+
+**Response**:
+```typescript
+{
+  success: boolean
+  message: string                // "Alert resolved" ou "Alert not found"
+  timestamp: string
+}
+```
+
+---
+
+## WebSocket Endpoint
+
+### `WS /api/live/ws`
+
+Endpoint WebSocket para comunicação em tempo real com Live Components.
+
+#### Conexão
+
+```javascript
+const ws = new WebSocket('ws://localhost:3000/api/live/ws')
+
+ws.onopen = () => {
+  console.log('Connected to Live Components')
+}
+
+ws.onmessage = (event) => {
+  const message = JSON.parse(event.data)
+  console.log('Received:', message)
+}
+```
+
+#### Tipos de Mensagens
+
+##### Cliente → Servidor
+
+**COMPONENT_MOUNT** - Monta um componente
+```typescript
+{
+  type: "COMPONENT_MOUNT"
+  componentId: string
+  payload: {
+    componentName: string
+    props?: Record<string, any>
+    room?: string
+    userId?: string
+  }
+  requestId?: string
+  expectResponse?: boolean
+}
+```
+
+**COMPONENT_UNMOUNT** - Desmonta um componente
+```typescript
+{
+  type: "COMPONENT_UNMOUNT"
+  componentId: string
+  requestId?: string
+}
+```
+
+**CALL_ACTION** - Chama uma ação no componente
+```typescript
+{
+  type: "CALL_ACTION"
+  componentId: string
+  action: string
+  payload?: any
+  requestId?: string
+  expectResponse?: boolean
+}
+```
+
+**PROPERTY_UPDATE** - Atualiza propriedade do componente
+```typescript
+{
+  type: "PROPERTY_UPDATE"
+  componentId: string
+  payload: {
+    property: string
+    value: any
+  }
+  requestId?: string
+}
+```
+
+**COMPONENT_PING** - Mantém a conexão ativa
+```typescript
+{
+  type: "COMPONENT_PING"
+  componentId: string
+  requestId?: string
+}
+```
+
+##### Servidor → Cliente
+
+**CONNECTION_ESTABLISHED** - Confirmação de conexão
+```typescript
+{
+  type: "CONNECTION_ESTABLISHED"
+  connectionId: string
+  timestamp: number
+  features: {
+    compression: boolean
+    encryption: boolean
+    offlineQueue: boolean
+    loadBalancing: boolean
+  }
+}
+```
+
+**COMPONENT_MOUNTED** - Componente montado com sucesso
+```typescript
+{
+  type: "COMPONENT_MOUNTED"
+  componentId: string
+  success: boolean
+  result?: any
+  error?: string
+  requestId?: string
+  timestamp: number
+}
+```
+
+**COMPONENT_UPDATE** - Atualização do estado do componente
+```typescript
+{
+  type: "COMPONENT_UPDATE"
+  componentId: string
+  state: any
+  timestamp: number
+}
+```
+
+**ACTION_RESPONSE** - Resposta de uma ação
+```typescript
+{
+  type: "ACTION_RESPONSE"
+  componentId: string
+  success: boolean
+  result?: any
+  error?: string
+  requestId?: string
+  timestamp: number
+}
+```
+
+**COMPONENT_PONG** - Resposta ao ping
+```typescript
+{
+  type: "COMPONENT_PONG"
+  componentId: string
+  success: boolean
+  requestId?: string
+  timestamp: number
+}
+```
+
+**ERROR** - Erro genérico
+```typescript
+{
+  type: "ERROR"
+  error: string
+  timestamp: number
+}
+```
+
+---
+
+## Criando Live Components
+
+### Estrutura Base
+
+Crie seu componente em `app/server/live/`:
+
+```typescript
+// app/server/live/MyComponent.ts
+import { LiveComponent } from '@/core/server/live/LiveComponent'
+
+export class MyComponent extends LiveComponent {
+  // Estado inicial
+  state = {
+    counter: 0,
+    message: 'Hello'
+  }
+
+  // Ações disponíveis
+  async increment() {
+    this.state.counter++
+    await this.emit('updated', { counter: this.state.counter })
+  }
+
+  async updateMessage(newMessage: string) {
+    this.state.message = newMessage
+    await this.emit('message-changed', { message: this.state.message })
+  }
+
+  // Lifecycle hooks
+  async onMount() {
+    console.log('Component mounted:', this.componentId)
+  }
+
+  async onUnmount() {
+    console.log('Component unmounted:', this.componentId)
+  }
+}
+```
+
+### Auto-Discovery
+
+Componentes em `app/server/live/` são automaticamente descobertos durante o build:
+
+```bash
+bun run build  # Gera core/server/live/auto-generated-components.ts
+```
+
+---
+
+## Exemplo Completo
+
+### Servidor (Live Component)
+
+```typescript
+// app/server/live/CounterComponent.ts
+import { LiveComponent } from '@/core/server/live/LiveComponent'
+
+export class CounterComponent extends LiveComponent {
+  state = {
+    count: 0,
+    history: [] as number[]
+  }
+
+  async increment() {
+    this.state.count++
+    this.state.history.push(this.state.count)
+
+    // Emite atualização para o cliente
+    await this.emit('count-updated', {
+      count: this.state.count,
+      history: this.state.history
+    })
+  }
+
+  async reset() {
+    this.state.count = 0
+    this.state.history = []
+    await this.emit('count-reset', { count: 0 })
+  }
+
+  async onMount() {
+    // Inicialização quando o componente é montado
+    console.log('Counter mounted')
+  }
+}
+```
+
+### Cliente (React/TypeScript)
+
+```typescript
+// app/client/src/components/LiveCounter.tsx
+import { useEffect, useState } from 'react'
+
+export function LiveCounter() {
+  const [ws, setWs] = useState<WebSocket | null>(null)
+  const [count, setCount] = useState(0)
+  const [componentId] = useState(`counter-${Date.now()}`)
+
+  useEffect(() => {
+    const websocket = new WebSocket('ws://localhost:3000/api/live/ws')
+
+    websocket.onopen = () => {
+      // Monta o componente no servidor
+      websocket.send(JSON.stringify({
+        type: 'COMPONENT_MOUNT',
+        componentId,
+        payload: {
+          componentName: 'CounterComponent'
+        }
+      }))
+    }
+
+    websocket.onmessage = (event) => {
+      const message = JSON.parse(event.data)
+
+      if (message.type === 'COMPONENT_UPDATE') {
+        setCount(message.state.count)
+      }
+    }
+
+    setWs(websocket)
+
+    return () => {
+      // Desmonta o componente
+      websocket.send(JSON.stringify({
+        type: 'COMPONENT_UNMOUNT',
+        componentId
+      }))
+      websocket.close()
+    }
+  }, [])
+
+  const handleIncrement = () => {
+    if (ws) {
+      ws.send(JSON.stringify({
+        type: 'CALL_ACTION',
+        componentId,
+        action: 'increment'
+      }))
+    }
+  }
+
+  const handleReset = () => {
+    if (ws) {
+      ws.send(JSON.stringify({
+        type: 'CALL_ACTION',
+        componentId,
+        action: 'reset'
+      }))
+    }
+  }
+
+  return (
+    <div>
+      <h2>Live Counter: {count}</h2>
+      <button onClick={handleIncrement}>Increment</button>
+      <button onClick={handleReset}>Reset</button>
+    </div>
+  )
+}
+```
+
+---
+
+## Performance e Escalabilidade
+
+### Connection Pooling
+
+O sistema suporta pools de conexões para melhor distribuição de carga:
+
+```typescript
+// Configuração de pools (exemplo conceitual)
+const poolConfig = {
+  maxConnectionsPerPool: 1000,
+  poolStrategy: 'round-robin', // ou 'least-connections'
+  healthCheckInterval: 30000
+}
+```
+
+### Monitoramento
+
+Use os endpoints de performance para monitorar:
+
+- **Latência de mensagens**
+- **Tempo de renderização**
+- **Taxa de erro**
+- **Utilização de conexões**
+
+```bash
+# Dashboard completo
+curl http://localhost:3000/api/live/performance/dashboard
+
+# Métricas de um componente específico
+curl http://localhost:3000/api/live/performance/components/CounterComponent
+```
+
+---
+
+## Troubleshooting
+
+### Conexão WebSocket falha
+
+**Sintoma**: `WebSocket connection failed`
+
+**Solução**:
+1. Verifique se o servidor está rodando: `curl http://localhost:3000/api/live/health`
+2. Confirme que WebSockets não estão bloqueados por proxy/firewall
+3. Use `ws://` para desenvolvimento, `wss://` para produção
+
+### Componente não encontrado
+
+**Sintoma**: `Component 'MyComponent' not found`
+
+**Solução**:
+1. Certifique-se que o componente está em `app/server/live/`
+2. Execute `bun run build` para regenerar o registro
+3. Verifique se a classe estende `LiveComponent`
+
+### Mensagens não chegam ao cliente
+
+**Sintoma**: Cliente não recebe atualizações
+
+**Solução**:
+1. Verifique se `await this.emit()` está sendo chamado
+2. Confirme que o `componentId` está correto
+3. Monitore logs do servidor para erros
+
+---
+
+## Referências
+
+- **Código fonte**: `core/server/live/`
+- **Exemplo**: `app/server/live/LiveClockComponent.ts`
+- **Testes**: `core/server/live/__tests__/`
+- **Documentação geral**: `ai-context/development/live-components.md`

--- a/ai-context/reference/static-files-api.md
+++ b/ai-context/reference/static-files-api.md
@@ -1,0 +1,579 @@
+# Static Files API Reference
+
+## Visão Geral
+
+O **Static Files Plugin** fornece funcionalidade para servir arquivos estáticos e uploads com cache apropriado, segurança e suporte a MIME types.
+
+### Características
+
+- ✅ **Servir Arquivos Públicos**: Pasta `public/` para assets estáticos
+- ✅ **Gerenciamento de Uploads**: Pasta `uploads/` para arquivos enviados por usuários
+- ✅ **Cache Inteligente**: Headers de cache configuráveis (padrão: 1 ano)
+- ✅ **MIME Types**: Detecção automática baseada em extensão
+- ✅ **Segurança**: Proteção contra path traversal
+- ✅ **ETag Support**: ETags baseados em modificação + tamanho
+- ✅ **Rotas Configuráveis**: Prefixos customizáveis para dev/prod
+
+---
+
+## Configuração
+
+### Variáveis de Ambiente
+
+```bash
+# .env
+STATIC_FILES_PUBLIC_DIR=public          # Diretório de arquivos públicos
+STATIC_FILES_UPLOADS_DIR=uploads        # Diretório de uploads
+STATIC_FILES_CACHE_MAX_AGE=31536000     # Cache em segundos (1 ano)
+STATIC_FILES_ENABLE_PUBLIC=true         # Habilitar pasta public
+STATIC_FILES_ENABLE_UPLOADS=true        # Habilitar pasta uploads
+STATIC_FILES_PUBLIC_ROUTE=/api/static   # Rota para arquivos públicos
+STATIC_FILES_UPLOADS_ROUTE=/api/uploads # Rota para uploads
+```
+
+### Configuração Programática
+
+```typescript
+// fluxstack.config.ts
+export default {
+  staticFiles: {
+    publicDir: 'public',
+    uploadsDir: 'uploads',
+    cacheMaxAge: 31536000, // 1 ano
+    enablePublic: true,
+    enableUploads: true,
+    publicRoute: '/api/static',  // Evita conflitos com Vite em dev
+    uploadsRoute: '/api/uploads'
+  }
+}
+```
+
+---
+
+## Endpoints HTTP
+
+### Informações de Configuração
+
+#### `GET /api/static/info`
+
+Retorna a configuração atual do plugin de arquivos estáticos.
+
+**Tags**: `Static Files`, `Configuration`
+
+**Response**:
+```typescript
+{
+  success: boolean
+  config: {
+    publicDir: string           // "public"
+    uploadsDir: string          // "uploads"
+    enablePublic: boolean       // true/false
+    enableUploads: boolean      // true/false
+    cacheMaxAge: number         // Segundos (ex: 31536000)
+  }
+  paths: {
+    publicPath: string          // Caminho absoluto no sistema
+    uploadsPath: string         // Caminho absoluto no sistema
+    publicUrl: string           // "/api/static"
+    uploadsUrl: string          // "/api/uploads"
+  }
+  timestamp: string             // ISO 8601
+}
+```
+
+**Exemplo**:
+```bash
+curl http://localhost:3000/api/static/info
+```
+
+**Response Example**:
+```json
+{
+  "success": true,
+  "config": {
+    "publicDir": "public",
+    "uploadsDir": "uploads",
+    "enablePublic": true,
+    "enableUploads": true,
+    "cacheMaxAge": 31536000
+  },
+  "paths": {
+    "publicPath": "/home/user/project/public",
+    "uploadsPath": "/home/user/project/uploads",
+    "publicUrl": "/api/static",
+    "uploadsUrl": "/api/uploads"
+  },
+  "timestamp": "2025-01-13T12:00:00.000Z"
+}
+```
+
+---
+
+### Servir Arquivos Públicos
+
+#### `GET /api/static/*`
+
+Serve arquivos da pasta `public/`.
+
+**Pattern**: `/api/static/{path-to-file}`
+
+**Headers de Resposta**:
+- `content-type`: MIME type detectado
+- `content-length`: Tamanho do arquivo em bytes
+- `last-modified`: Data da última modificação
+- `cache-control`: `public, max-age={cacheMaxAge}`
+- `etag`: ETag baseado em mtime + size
+- `x-content-type-options`: `nosniff` (para imagens)
+
+**Exemplos**:
+
+```bash
+# Servir imagem
+curl http://localhost:3000/api/static/logo.png
+
+# Servir CSS
+curl http://localhost:3000/api/static/styles/main.css
+
+# Servir JavaScript
+curl http://localhost:3000/api/static/js/app.js
+
+# Servir fonte
+curl http://localhost:3000/api/static/fonts/Inter.woff2
+```
+
+**Estrutura de Diretórios**:
+```
+public/
+├── logo.png
+├── favicon.ico
+├── styles/
+│   └── main.css
+├── js/
+│   └── app.js
+└── fonts/
+    └── Inter.woff2
+```
+
+**Respostas de Erro**:
+
+**404 - Arquivo não encontrado**:
+```json
+{
+  "error": "File not found",
+  "path": "/logo-missing.png",
+  "timestamp": "2025-01-13T12:00:00.000Z"
+}
+```
+
+**400 - Path inválido** (tentativa de path traversal):
+```json
+{
+  "error": "Invalid file path"
+}
+```
+
+**404 - Não é um arquivo** (pasta ou symlink):
+```json
+{
+  "error": "Not a file"
+}
+```
+
+---
+
+### Servir Uploads
+
+#### `GET /api/uploads/*`
+
+Serve arquivos da pasta `uploads/`.
+
+**Pattern**: `/api/uploads/{path-to-file}`
+
+Funciona de forma idêntica a `/api/static/*`, mas serve arquivos da pasta `uploads/`.
+
+**Exemplos**:
+
+```bash
+# Avatar de usuário
+curl http://localhost:3000/api/uploads/avatars/user-123.jpg
+
+# Documento enviado
+curl http://localhost:3000/api/uploads/documents/report.pdf
+
+# Anexo
+curl http://localhost:3000/api/uploads/attachments/file.zip
+```
+
+**Estrutura de Diretórios**:
+```
+uploads/
+├── avatars/
+│   ├── user-123.jpg
+│   └── user-456.png
+├── documents/
+│   └── report.pdf
+└── attachments/
+    └── file.zip
+```
+
+---
+
+## MIME Types Suportados
+
+O plugin detecta automaticamente o tipo MIME baseado na extensão do arquivo:
+
+### Imagens
+| Extensão | MIME Type |
+|----------|-----------|
+| `.jpg`, `.jpeg` | `image/jpeg` |
+| `.png` | `image/png` |
+| `.gif` | `image/gif` |
+| `.webp` | `image/webp` |
+| `.svg` | `image/svg+xml` |
+| `.ico` | `image/x-icon` |
+
+### Documentos
+| Extensão | MIME Type |
+|----------|-----------|
+| `.pdf` | `application/pdf` |
+| `.txt` | `text/plain` |
+| `.json` | `application/json` |
+| `.xml` | `application/xml` |
+
+### Web Assets
+| Extensão | MIME Type |
+|----------|-----------|
+| `.css` | `text/css` |
+| `.js` | `application/javascript` |
+| `.html`, `.htm` | `text/html` |
+
+### Fontes
+| Extensão | MIME Type |
+|----------|-----------|
+| `.woff` | `font/woff` |
+| `.woff2` | `font/woff2` |
+| `.ttf` | `font/ttf` |
+| `.otf` | `font/otf` |
+
+### Áudio/Vídeo
+| Extensão | MIME Type |
+|----------|-----------|
+| `.mp3` | `audio/mpeg` |
+| `.mp4` | `video/mp4` |
+| `.webm` | `video/webm` |
+| `.ogg` | `audio/ogg` |
+
+**Fallback**: Arquivos com extensões desconhecidas recebem `application/octet-stream`.
+
+---
+
+## Segurança
+
+### Proteção Contra Path Traversal
+
+O plugin valida todos os caminhos para prevenir acesso a arquivos fora dos diretórios permitidos:
+
+```typescript
+// ❌ Bloqueado - Path traversal
+GET /api/static/../../../etc/passwd
+
+// ❌ Bloqueado - Path absoluto
+GET /api/static//etc/passwd
+
+// ✅ Permitido - Path relativo válido
+GET /api/static/images/logo.png
+```
+
+**Implementação**:
+```typescript
+const isPathSafe = (filePath: string, basePath: string): boolean => {
+  const resolvedPath = resolve(basePath, filePath)
+  return resolvedPath.startsWith(basePath)
+}
+```
+
+### Headers de Segurança
+
+Para arquivos de imagem, o header `x-content-type-options: nosniff` é adicionado para prevenir MIME type sniffing.
+
+---
+
+## Cache e Performance
+
+### Cache Headers
+
+Todos os arquivos são servidos com headers de cache otimizados:
+
+```http
+Cache-Control: public, max-age=31536000
+ETag: "1673618400000-12345"
+Last-Modified: Thu, 13 Jan 2025 12:00:00 GMT
+```
+
+### ETags
+
+ETags são gerados usando timestamp de modificação + tamanho do arquivo:
+
+```typescript
+const etag = `"${stats.mtime.getTime()}-${stats.size}"`
+```
+
+Isso permite que navegadores façam cache eficiente usando `If-None-Match`.
+
+### Conditional Requests
+
+Clientes podem usar `If-None-Match` ou `If-Modified-Since`:
+
+```bash
+curl -H "If-None-Match: \"1673618400000-12345\"" \
+  http://localhost:3000/api/static/logo.png
+```
+
+Se o arquivo não mudou, retorna **304 Not Modified**.
+
+---
+
+## Casos de Uso Comuns
+
+### 1. Servir Assets do Frontend
+
+```html
+<!-- public/index.html -->
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" href="/api/static/styles/main.css">
+  <link rel="icon" href="/api/static/favicon.ico">
+</head>
+<body>
+  <img src="/api/static/logo.png" alt="Logo">
+  <script src="/api/static/js/app.js"></script>
+</body>
+</html>
+```
+
+### 2. Upload e Servir Avatares
+
+```typescript
+// Backend - Salvar avatar
+import { writeFile } from 'fs/promises'
+import { join } from 'path'
+
+async function saveAvatar(userId: string, fileBuffer: Buffer) {
+  const filename = `user-${userId}.jpg`
+  const filepath = join(process.cwd(), 'uploads', 'avatars', filename)
+  await writeFile(filepath, fileBuffer)
+
+  return `/api/uploads/avatars/${filename}`
+}
+
+// Frontend - Exibir avatar
+function UserAvatar({ userId }: { userId: string }) {
+  return (
+    <img
+      src={`http://localhost:3000/api/uploads/avatars/user-${userId}.jpg`}
+      alt="Avatar"
+    />
+  )
+}
+```
+
+### 3. Download de Documentos
+
+```typescript
+// React component
+function DownloadButton({ documentId }: { documentId: string }) {
+  const handleDownload = () => {
+    const url = `http://localhost:3000/api/uploads/documents/${documentId}.pdf`
+    window.open(url, '_blank')
+  }
+
+  return <button onClick={handleDownload}>Download PDF</button>
+}
+```
+
+### 4. Servir Fontes Customizadas
+
+```css
+/* public/styles/fonts.css */
+@font-face {
+  font-family: 'Inter';
+  src: url('/api/static/fonts/Inter.woff2') format('woff2'),
+       url('/api/static/fonts/Inter.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+}
+```
+
+---
+
+## Estrutura de Diretórios Recomendada
+
+### Public (Assets Estáticos)
+
+```
+public/
+├── favicon.ico
+├── robots.txt
+├── images/
+│   ├── logo.png
+│   ├── banner.jpg
+│   └── icons/
+│       ├── arrow.svg
+│       └── menu.svg
+├── styles/
+│   ├── main.css
+│   └── fonts.css
+├── fonts/
+│   ├── Inter.woff2
+│   └── Inter.woff
+└── js/
+    └── polyfills.js
+```
+
+### Uploads (Arquivos Dinâmicos)
+
+```
+uploads/
+├── avatars/
+│   ├── user-1.jpg
+│   └── user-2.png
+├── documents/
+│   ├── invoice-2025-01.pdf
+│   └── report-q1.pdf
+├── attachments/
+│   └── file-abc123.zip
+└── temp/
+    └── upload-processing.tmp
+```
+
+---
+
+## Integração com Eden Treaty
+
+```typescript
+// app/client/src/lib/static-api.ts
+import { api } from './eden-api'
+
+export const staticApi = {
+  // Obter informações de configuração
+  async getInfo() {
+    const { data, error } = await api.static.info.get()
+    return data
+  },
+
+  // Construir URL para asset público
+  getPublicUrl(path: string) {
+    return `/api/static/${path}`
+  },
+
+  // Construir URL para upload
+  getUploadUrl(path: string) {
+    return `/api/uploads/${path}`
+  }
+}
+
+// Uso
+const info = await staticApi.getInfo()
+console.log('Public URL:', info.paths.publicUrl)
+
+const logoUrl = staticApi.getPublicUrl('logo.png')
+const avatarUrl = staticApi.getUploadUrl('avatars/user-123.jpg')
+```
+
+---
+
+## Troubleshooting
+
+### Arquivo não encontrado (404)
+
+**Sintoma**: `File not found` mesmo existindo o arquivo
+
+**Soluções**:
+1. Verifique se o arquivo está na pasta correta (`public/` ou `uploads/`)
+2. Confirme que os diretórios foram criados (criados automaticamente no boot)
+3. Verifique permissões de leitura do arquivo
+4. Use o endpoint `/api/static/info` para confirmar paths
+
+### Cache não está funcionando
+
+**Sintoma**: Navegador sempre baixa o arquivo
+
+**Soluções**:
+1. Verifique headers de resposta com DevTools
+2. Confirme que `cacheMaxAge` está configurado
+3. Limpe cache do navegador
+4. Use ETags para validação condicional
+
+### MIME type incorreto
+
+**Sintoma**: Arquivo baixa ao invés de exibir
+
+**Soluções**:
+1. Verifique a extensão do arquivo
+2. Adicione extensão na lista de MIME types se necessário
+3. Use `content-type` header correto manualmente se necessário
+
+### Path traversal bloqueado
+
+**Sintoma**: `Invalid file path` para paths válidos
+
+**Soluções**:
+1. Não use `../` nos caminhos
+2. Use apenas caminhos relativos
+3. Evite barras duplas `//`
+
+---
+
+## Performance Tips
+
+### 1. Use CDN em Produção
+
+```typescript
+// Configuração de CDN
+const CDN_URL = process.env.CDN_URL || ''
+
+function getAssetUrl(path: string) {
+  return CDN_URL
+    ? `${CDN_URL}/static/${path}`
+    : `/api/static/${path}`
+}
+```
+
+### 2. Otimize Imagens
+
+```bash
+# Comprimir imagens antes de adicionar a public/
+npm install -g sharp-cli
+
+sharp-cli resize 800 600 input.jpg -o output.jpg
+```
+
+### 3. Use WebP para Imagens Modernas
+
+```html
+<picture>
+  <source srcset="/api/static/image.webp" type="image/webp">
+  <img src="/api/static/image.jpg" alt="Fallback">
+</picture>
+```
+
+### 4. Prefetch Assets Importantes
+
+```html
+<link rel="prefetch" href="/api/static/hero-image.jpg">
+<link rel="preload" href="/api/static/fonts/Inter.woff2" as="font">
+```
+
+---
+
+## Referências
+
+- **Código fonte**: `core/server/plugins/static-files-plugin.ts`
+- **Configuração**: `fluxstack.config.ts` → `staticFiles`
+- **Variáveis de ambiente**: `ai-context/reference/environment-vars.md`
+- **Build pipeline**: `ai-context/project/build-pipeline.md`

--- a/app/server/routes/index.ts
+++ b/app/server/routes/index.ts
@@ -1,4 +1,5 @@
 import { Elysia, t } from "elysia"
+import { usersRoutes } from "./users.routes"
 
 export const apiRoutes = new Elysia({ prefix: "/api" })
   .get("/", () => ({ message: "🔥 Hot Reload funcionando! FluxStack API v1.4.0 ⚡" }), {
@@ -31,3 +32,5 @@ export const apiRoutes = new Elysia({ prefix: "/api" })
       description: 'Returns the current health status of the API server'
     }
   })
+  // Register users routes
+  .use(usersRoutes)


### PR DESCRIPTION
Added complete TypeBox schemas, tags, summaries and descriptions for all Users CRUD endpoints:

✅ GET /api/users - Get All Users
- Schema: GetUsersResponseSchema with array of users
- Summary: "Get All Users"
- Tags: Users, CRUD
- Returns: { success, users[], count }

✅ GET /api/users/:id - Get User by ID
- Schema: GetUserResponseSchema (union success/error)
- Summary: "Get User by ID"
- Tags: Users, CRUD
- Parameters: id (User ID)
- Responses: 200 (user), 400 (invalid ID), 404 (not found)

✅ POST /api/users - Create New User
- Schema: CreateUserRequestSchema & CreateUserResponseSchema
- Summary: "Create New User"
- Tags: Users, CRUD
- Body: { name (min 2 chars), email (valid format) }
- Validation: Required fields, email uniqueness
- Responses: 200 (created), 400 (validation errors)

✅ DELETE /api/users/:id - Delete User
- Schema: DeleteUserResponseSchema
- Summary: "Delete User"
- Tags: Users, CRUD
- Parameters: id (User ID to delete)
- Responses: 200 (deleted), 400 (invalid ID)

Infrastructure:
- Registered usersRoutes in app/server/routes/index.ts
- All routes now appear in Swagger UI under "Users" tag
- Request/response schemas provide full type safety
- Proper error handling documented

Also added comprehensive API reference documentation:
- ai-context/reference/live-components-api.md
- ai-context/reference/static-files-api.md

Result: 100% of main API routes (/api/*) are now fully documented